### PR TITLE
Added an additional check to handle `null` case for expiration date

### DIFF
--- a/app/Services/DomainService.php
+++ b/app/Services/DomainService.php
@@ -41,11 +41,11 @@ class DomainService
             return false;
         }
 
-        if(! $monitor->domain_expires_at->equalTo(Carbon::parse($domainInfo['expirationDate']))){
+        if(! $monitor->domain_expires_at || ! $monitor->domain_expires_at->equalTo(Carbon::parse($domainInfo['expirationDate']))){
             $this->updateDomainExpiration($monitor, $domainInfo['expirationDate']);
         }
 
-        return $this->checkAndNotifyExpiration($monitor);   
+        return $this->checkAndNotifyExpiration($monitor);
     }
 
     protected function checkAndNotifyExpiration(Monitor $monitor) : bool

--- a/app/Services/DomainService.php
+++ b/app/Services/DomainService.php
@@ -41,7 +41,8 @@ class DomainService
             return false;
         }
 
-        if(! $monitor->domain_expires_at || ! $monitor->domain_expires_at->equalTo(Carbon::parse($domainInfo['expirationDate']))){
+        $expirationDate = Carbon::parse($domainInfo['expirationDate']);
+        if (!$monitor->domain_expires_at || !$monitor->domain_expires_at->equalTo($expirationDate)) {
             $this->updateDomainExpiration($monitor, $domainInfo['expirationDate']);
         }
 


### PR DESCRIPTION
## Targets #53 

### Description
* Added an additional check for `$monitor->domain_expires_at` to handle the already `null` value.

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
