### PR TITLE
Added dynamic casts to the monitor table for `domain_expires_at`

### DIFF
--- a/app/Models/Monitor.php
+++ b/app/Models/Monitor.php
@@ -9,9 +9,12 @@ use Spatie\UptimeMonitor\Models\Monitor as SpatieMonitor;
 
 class Monitor extends SpatieMonitor
 {
-    protected $casts = [
-        'domain_expires_at' => 'datetime',
-    ];
+    public function __construct()
+    {
+        $this->casts = array_merge($this->casts, [
+            'domain_expires_at' => 'datetime',
+        ]);
+    }
 
     public function scopeDomainCheckEnabled(Builder $query): Collection
     {


### PR DESCRIPTION
## Targets #53 
<!--- If there is an open issue, please link to the issue here by replacing [ISSUE_ID]-->

<!--- Please complete the following steps and check these boxes before filing your PR: -->

### Description
* Added a dynamic cast addition to the custom monitor model.
* The error was due to the custom casts overriding the package's casts for other datetime columns.

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
