### PR TITLE
Uptime dateissue fix

### DIFF
--- a/app/Models/Monitor.php
+++ b/app/Models/Monitor.php
@@ -10,6 +10,7 @@ class Monitor extends SpatieMonitor
 {
     public function __construct()
     {
+        parent::__construct();
         $this->casts = array_merge($this->casts, [
             'domain_expires_at' => 'datetime',
         ]);


### PR DESCRIPTION
### Description
Because the parent's constructor was overridden and wasn't being called, the logic that saves the last status update time was not getting updated. This field was being used to calculate the downtimePeriod
<!--- Describe your changes in detail -->
<!--- Why these changes are required? What existing problem does the pull request solve? -->

### Checklist:
<!--- Mark the checkboxes accordingly. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have performed a self-review of my own code.
